### PR TITLE
Update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,13 +4,13 @@
 DOCKER_USER=sudo
 
 # Container data for docker-compose.yml
-PROJECT_TITLE="SYMFONY"         # <- this name will be prompt for Makefile recipes
-PROJECT_ABBR="sf-nginx-php"     # <- part of the service image tag - useful if similar services are running
+PROJECT_TITLE="SYMFONY"# <- this name will be prompt for Makefile recipes
+PROJECT_ABBR="sf-nginx-php"# <- part of the service image tag - useful if similar services are running
 
 # Symfony container
 PROJECT_HOST="127.0.0.1"                    # <- for this project is not necessary
 PROJECT_PORT="8888"                         # <- port access container service on local machine
-PROJECT_CAAS="symfony-app"                  # <- container as a service name to build service
+PROJECT_CAAS="symfony-app"# <- container as a service name to build service
 PROJECT_PATH="../../../symfony"             # <- path where application is binded from container to local
 
 # Database service container


### PR DESCRIPTION
I delete the spaces after the value because I had the error : "invalid project name "symfony-app                  ": must consist only of lowercase alphanumeric characters, hyphens, and underscores as well as start with a letter or number".
It taked the spaces between "symfony-app" and the comment.